### PR TITLE
Remove arrayvec dependency in favour of array.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,14 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,11 +164,6 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "nodrop"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "num-derive"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,7 +306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stew"
 version = "0.2.0"
 dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -415,7 +401,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5cde24d1b2e2216a726368b2363a273739c91f4e3eb4e0dd12d672d396ad989"
@@ -435,7 +420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
-"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum num-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d2c31b75c36a993d30c7a13d70513cb93f02acafdd5b7ba250f9b0e18615de7"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ categories = ["multimedia::images", "command-line-utilities"]
 output-test-images = []
 
 [dependencies]
-arrayvec = "0.4.7"
 clap = "2.32.0"
 image = "0.21.0"
 

--- a/src/bin/filter3x3.rs
+++ b/src/bin/filter3x3.rs
@@ -1,4 +1,3 @@
-use arrayvec::ArrayVec;
 use clap::AppSettings;
 use clap::Arg;
 use stew_lib::get_app_skeleton;
@@ -132,18 +131,19 @@ fn main() -> Result<(), String> {
                 Some(t2),
                 Some(t3),
             ) => {
-                let mut vec = ArrayVec::new();
-                vec.push(parse_fp32(f1)?);
-                vec.push(parse_fp32(f2)?);
-                vec.push(parse_fp32(f3)?);
-                vec.push(parse_fp32(s1)?);
-                vec.push(parse_fp32(s2)?);
-                vec.push(parse_fp32(s3)?);
-                vec.push(parse_fp32(t1)?);
-                vec.push(parse_fp32(t2)?);
-                vec.push(parse_fp32(t3)?);
+                let arr: [f32; 9] = [
+                    parse_fp32(f1)?,
+                    parse_fp32(f2)?,
+                    parse_fp32(f3)?,
+                    parse_fp32(s1)?,
+                    parse_fp32(s2)?,
+                    parse_fp32(s3)?,
+                    parse_fp32(t1)?,
+                    parse_fp32(t2)?,
+                    parse_fp32(t3)?,
+                ];
 
-                let op = operation_by_name(COMMAND_NAME, OpArg::FloatingPointArrayVec9(vec));
+                let op = operation_by_name(COMMAND_NAME, OpArg::FloatingPointArray9(arr));
 
                 run(&matches, Some(op?))
             }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,5 +1,3 @@
-use arrayvec::ArrayVec;
-
 #[cfg(test)]
 mod mod_test_includes;
 
@@ -11,7 +9,7 @@ pub enum Operation {
     Brighten(i32),
     Contrast(f32),
     Crop(u32, u32, u32, u32),
-    Filter3x3(ArrayVec<[f32; 9]>),
+    Filter3x3([f32; 9]),
     FlipHorizontal,
     FlipVertical,
     GrayScale,
@@ -30,7 +28,7 @@ pub enum OpArg {
     Integer(i32),
     UnsignedIntegerTuple2(u32, u32),
     UnsignedIntegerTuple4(u32, u32, u32, u32),
-    FloatingPointArrayVec9(ArrayVec<[f32; 9]>),
+    FloatingPointArray9([f32; 9]),
     FloatingPointIntegerTuple2(f32, i32),
 }
 
@@ -42,7 +40,7 @@ pub fn operation_by_name(name: &str, value: OpArg) -> Result<Operation, String> 
         ("crop", OpArg::UnsignedIntegerTuple4(u0, u1, u2, u3)) => {
             Ok(Operation::Crop(u0, u1, u2, u3))
         }
-        ("filter3x3", OpArg::FloatingPointArrayVec9(v)) => Ok(Operation::Filter3x3(v)),
+        ("filter3x3", OpArg::FloatingPointArray9(v)) => Ok(Operation::Filter3x3(v)),
         ("fliph", OpArg::Empty) => Ok(Operation::FlipHorizontal),
         ("flipv", OpArg::Empty) => Ok(Operation::FlipVertical),
         ("grayscale", OpArg::Empty) => Ok(Operation::GrayScale),
@@ -120,14 +118,11 @@ mod tests {
 
     #[test]
     fn filter3x3_ok() {
-        let array = ArrayVec::<[f32; 9]>::default();
+        let array: [f32; 9] = [1.0; 9];
 
-        let actual = operation_by_name("filter3x3", OpArg::FloatingPointArrayVec9(array));
+        let actual = operation_by_name("filter3x3", OpArg::FloatingPointArray9(array));
 
-        assert_eq!(
-            actual,
-            Ok(Operation::Filter3x3(ArrayVec::<[f32; 9]>::default()))
-        );
+        assert_eq!(actual, Ok(Operation::Filter3x3(array)));
     }
 
     // fliph

--- a/src/operations/transformations.rs
+++ b/src/operations/transformations.rs
@@ -26,7 +26,7 @@ impl ApplyOperation<Operation, DynamicImage, String> for DynamicImage {
             // We need to ensure here that Filter3x3's `it` (&[f32]) has length 9.
             // Otherwise it will panic, see: https://docs.rs/image/0.19.0/src/image/dynimage.rs.html#349
             // This check already happens within the `parse` module.
-            Operation::Filter3x3(ref it) => Ok(self.filter3x3(&it)),
+            Operation::Filter3x3(ref it) => Ok(self.filter3x3(it)),
             Operation::FlipHorizontal => Ok(self.fliph()),
             Operation::FlipVertical => Ok(self.flipv()),
             Operation::GrayScale => Ok(self.grayscale()),
@@ -97,7 +97,6 @@ pub fn apply_operations_on_image(
 
 #[cfg(test)]
 mod tests {
-    use arrayvec::ArrayVec;
     use image::GenericImageView;
 
     use crate::operations::mod_test_includes::*;
@@ -336,9 +335,7 @@ mod tests {
         let img: DynamicImage = setup_default_test_image();
         let cmp: DynamicImage = setup_default_test_image();
 
-        let operation = Operation::Filter3x3(ArrayVec::from([
-            1.0, 0.5, 0.0, 1.0, 0.5, 0.0, 1.0, 0.5, 0.0,
-        ]));
+        let operation = Operation::Filter3x3([1.0, 0.5, 0.0, 1.0, 0.5, 0.0, 1.0, 0.5, 0.0]);
 
         let done = img.apply_operation(&operation);
         assert!(done.is_ok());


### PR DESCRIPTION
The normal Rust array is not very flexible, but the truth is that it isn't needed for the current
code base. As such the dependency on ArrayVec was removed, and implementation replaced by [f32; 9]
arrays.