### PR TITLE
Update TravisCI config: don't build nightly versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: rust
 rust:
   - stable
-  - nightly
 os:
   - linux
   - windows
 matrix:
-  allow_failures:
-    - rust: nightly
   fast_finish: true


### PR DESCRIPTION
- The biggest con is the extra time each build takes, even if failures are allowed.
- Pro: knowing the nightly version compilation works too! :). Stew plans to stay on stable, so impact disabling impact is very small. 